### PR TITLE
Fix/studio

### DIFF
--- a/unsloth_studio/chat.py
+++ b/unsloth_studio/chat.py
@@ -21,7 +21,7 @@ os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 MODEL_NAME = "unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit"
 
-print("Installing packages for 🦥 Unsloth Studio ... Please wait 3 minute ...")
+print("Installing packages for 🦥 Unsloth Studio ... Please wait 5 minutes ...")
 
 install_first = [
     "pip", "install",

--- a/unsloth_studio/chat.py
+++ b/unsloth_studio/chat.py
@@ -25,10 +25,19 @@ print("Installing packages for 🦥 Unsloth Studio ... Please wait 1 minute ..."
 
 install_first = [
     "pip", "install",
-    "huggingface_hub", "hf_transfer", "triton",
+    "unsloth"
 ]
+
 install_first = subprocess.Popen(install_first)
 install_first.wait()
+
+uninstall_install_first = [
+    "pip", "uninstall", "-y",
+    "unsloth"
+]
+
+uninstall_install_first = subprocess.Popen(uninstall_install_first)
+uninstall_install_first.wait()
 
 install_second = [
     "pip", "install",

--- a/unsloth_studio/chat.py
+++ b/unsloth_studio/chat.py
@@ -21,7 +21,7 @@ os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 os.environ["GRADIO_ANALYTICS_ENABLED"] = "False"
 MODEL_NAME = "unsloth/Meta-Llama-3.1-8B-Instruct-bnb-4bit"
 
-print("Installing packages for 🦥 Unsloth Studio ... Please wait 1 minute ...")
+print("Installing packages for 🦥 Unsloth Studio ... Please wait 3 minute ...")
 
 install_first = [
     "pip", "install",
@@ -55,6 +55,7 @@ upgrade_huggingface_hub = [
 ]
 
 upgrade_huggingface_hub = subprocess.Popen(upgrade_huggingface_hub)
+upgrade_huggingface_hub.wait()
 
 
 from huggingface_hub import snapshot_download
@@ -72,14 +73,6 @@ from huggingface_hub.utils import disable_progress_bars
 disable_progress_bars()
 snapshot_download(repo_id = MODEL_NAME, repo_type = "model")
 
-install_second.wait()
-
-install_dependencies = [
-    "pip", "install", "--no-deps",
-    "xformers", "trl", "peft", "accelerate", "bitsandbytes",
-]
-install_dependencies = subprocess.Popen(install_dependencies)
-install_dependencies.wait()
 clear_output()
 
 

--- a/unsloth_studio/chat.py
+++ b/unsloth_studio/chat.py
@@ -41,10 +41,21 @@ uninstall_install_first.wait()
 
 install_second = [
     "pip", "install",
-    "gradio",
+    "gradio==4.44.1",
     "unsloth[colab-new]@git+https://github.com/unslothai/unsloth.git",
 ]
 install_second = subprocess.Popen(install_second)
+install_second.wait()
+
+upgrade_huggingface_hub = [
+    "pip", "install", 
+    "huggingface-hub",
+    "-U",
+    "--force-reinstall"
+]
+
+upgrade_huggingface_hub = subprocess.Popen(upgrade_huggingface_hub)
+
 
 from huggingface_hub import snapshot_download
 import warnings


### PR DESCRIPTION
There are several issue in the studio. The issue was issued by user in the discord. 

![image](https://github.com/user-attachments/assets/35674701-3995-43b6-8f6f-18b3a8a28b3d)

This issue is trigger when importing `unsloth`, but somehow the issue didn't happen inside finetune notebook. But Colab in general still using `huggingface_hub` version where there is no `EntryNotErrorFound` (so finetune notebook never call `huggingface_hub.errors.EntryNotErrorFound`). So what I did is to upgrade `huggingface_hub` as the last step of installation

```
Loading model ... Please wait 1 more minute! ...
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
[<ipython-input-1-d1dd531f71ba>](https://localhost:8080/#) in <cell line: 20>()
     18 get_ipython().system('git clone https://github.com/unslothai/studio > /dev/null 2>&1')
     19 with open("studio/unsloth_studio/chat.py", "r") as chat_module: code = chat_module.read()
---> 20 exec(code)

<string> in <module>

10 frames
[/usr/local/lib/python3.10/dist-packages/unsloth/__init__.py](https://localhost:8080/#) in <module>
    162 pass
    163 
--> 164 from .models import *
    165 from .save import *
    166 from .chat_templates import *

....

[/usr/local/lib/python3.10/dist-packages/huggingface_hub/repocard.py](https://localhost:8080/#) in <module>
     21 
     22 from . import constants
---> 23 from .errors import EntryNotFoundError
     24 from .utils import SoftTemporaryDirectory, logging, validate_hf_hub_args
     25 

ImportError: cannot import name 'EntryNotFoundError' from 'huggingface_hub.errors' (/usr/local/lib/python3.10/dist-packages/huggingface_hub/errors.py)
```

But, there's new error of this which happened because `studio` still use the old way of unsloth installation which I already fix it :

![image](https://github.com/user-attachments/assets/8c746626-acde-4875-b646-053238bbc46d)

Lastly, I need to specify the version of Gradio (4.44.1) for the exact, since there's a [migration](https://github.com/gradio-app/gradio/issues/9463) happening (specifically in `retry_button` which `studio` still uses)

You can try it immediately without merging the PR by using

```python
!git clone https://github.com/Erland366/unsloth-studio.git --branch fix/studio > /dev/null 2>&1
with open("unsloth-studio/unsloth_studio/chat.py", "r") as chat_module: code = chat_module.read()
exec(code)
```